### PR TITLE
Unblock CI by toggling audit.block-insecure off for older PHPUnit

### DIFF
--- a/.github/workflows/phpunit-matrix.yml
+++ b/.github/workflows/phpunit-matrix.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer remove --no-update --dev $(jq -r '.["require-dev"] | keys[]' composer.json)
+          composer config audit.block-insecure false
           composer require --no-update --dev phpunit/phpunit:^${{ matrix.phpunit }}
           composer install --no-interaction --prefer-dist --no-progress
 

--- a/tests/integration/e2e.phpt
+++ b/tests/integration/e2e.phpt
@@ -6,7 +6,8 @@ ob_start();
 passthru('./vendor/bin/phpunit tests/ExampleTest.php::testItWorks 2>/dev/null');
 passthru('./vendor/bin/phpunit tests/ExampleTest.php::test_one tests/ExampleTest.php::test_two 2>/dev/null');
 
-preg_match_all('/OK.*/', ob_get_clean(), $matches);
+$output = preg_replace('/\e\[[0-9;]*m/', '', ob_get_clean());
+preg_match_all('/OK.*/', $output, $matches);
 
 foreach ($matches[0] as $line) {
     echo "$line\n";


### PR DESCRIPTION
Composer now blocks PHPUnit 6.x/7.x due to security advisory PKSA-z3gr-8qht-p93v. Since these are dev dependencies used only for compatibility testing, disable the block in CI before install.